### PR TITLE
Update documentation to match current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Symphony
 
-PHP orchestration daemon for coding agents, built on Laravel Zero. Polls issue trackers (GitHub, Jira), creates isolated workspaces per issue, and dispatches Claude Code agent processes with multi-turn support and retry logic.
+PHP orchestration daemon for coding agents, built on Laravel Zero. Polls issue trackers (GitHub, Jira), creates isolated git worktrees per issue, and dispatches Claude Code agent processes with multi-turn support and retry logic.
 
 ## Project Structure
 
@@ -18,7 +18,7 @@ app/
     JiraTracker.php               # Jira REST API v3
     Issue.php                     # Normalized issue DTO
   Workflow/WorkflowLoader.php     # YAML frontmatter + Twig prompt parser
-  Workspace/WorkspaceManager.php  # Workspace lifecycle, hooks, cleanup
+  Workspace/WorkspaceManager.php  # Workspace lifecycle (git worktrees), setup commands, cleanup
 ```
 
 ## Development Commands
@@ -48,11 +48,11 @@ app/
 ## Configuration
 
 Workflow files (e.g., `WORKFLOW.md`) contain YAML frontmatter with these sections:
-- `tracker` - kind (github/jira), credentials, active/terminal states
+- `tracker` - kind (github/jira), credentials, active/terminal states, assignee/sprint/jql (Jira)
 - `polling` - interval_ms (default: 30000)
-- `workspace` - root path, hooks (after_create, before_run, before_remove)
-- `agent` - max_concurrent_agents (default: 10), max_turns (default: 20)
-- `claude` (optional) - command (default: `claude -p --output-format stream-json`), turn_timeout_ms (default: 3600000), stall_timeout_ms (default: 300000)
+- `workspace` - root path, setup commands (array), setup_timeout_ms (default: 60000)
+- `agent` - max_concurrent_agents (default: 10), max_turns (default: 20), max_retry_backoff_ms (default: 300000)
+- `claude` (optional) - command (default: `claude -p --verbose --output-format stream-json --dangerously-skip-permissions`), turn_timeout_ms (default: 3600000), stall_timeout_ms (default: 300000)
 
 ## When Updating Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Symphony
 
-A PHP orchestration daemon that coordinates coding agents against project issues. Symphony polls issue trackers (GitHub Issues, Jira), creates isolated workspaces, and dispatches [Claude Code](https://claude.ai/claude-code) agents to work on each issue with multi-turn support, retry logic, and resource constraints.
+A PHP orchestration daemon that coordinates coding agents against project issues. Symphony polls issue trackers (GitHub Issues, Jira), creates isolated git worktrees, and dispatches [Claude Code](https://claude.ai/claude-code) agents to work on each issue with multi-turn support, retry logic, and resource constraints.
 
 ## Prerequisites
 
@@ -34,7 +34,7 @@ composer install
    ./application run WORKFLOW.md
    ```
 
-   Symphony will poll your issue tracker, create workspaces for eligible issues, and launch Claude Code agents to work on them.
+   Symphony will poll your issue tracker, create git worktrees for eligible issues, and launch Claude Code agents to work on them.
 
 4. Stop gracefully with `Ctrl+C` (sends SIGINT). Running agents will finish their current turn before the daemon exits.
 
@@ -44,7 +44,7 @@ composer install
 2. **Sort** candidates by priority, creation date, and identifier
 3. **Filter** out issues that are already running, claimed, blocked, or in retry backoff
 4. **Fork** a child process per eligible issue (up to `max_concurrent_agents`)
-5. **Each child**: creates a workspace, runs hooks, renders the prompt template, and launches Claude Code
+5. **Each child**: creates a git worktree, runs setup commands, renders the prompt template, and launches Claude Code
 6. **Multi-turn**: if an agent fails, it retries with `--continue` up to `max_turns` times
 7. **Retry**: failed issues are re-queued with exponential backoff (10s * 2^attempt, capped at 5 min)
 8. **Reconcile**: on each tick, check worker status, kill stalled processes, and handle state transitions
@@ -57,7 +57,7 @@ composer install
   - [Configure Jira Tracker](docs/how-to/configure-jira-tracker.md)
   - [Write Workflow Templates](docs/how-to/write-workflow-templates.md)
   - [Tune Retry and Timeouts](docs/how-to/tune-retry-and-timeouts.md)
-  - [Configure Workspace Hooks](docs/how-to/configure-workspace-hooks.md)
+  - [Configure Workspace Setup](docs/how-to/configure-workspace-hooks.md)
 - **Reference**
   - [Configuration Schema](docs/reference/configuration.md)
   - [CLI Usage](docs/reference/cli.md)

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -24,7 +24,7 @@ Tracker  Workspace  Prompt  Agent  Workflow
 
 ### RunCommand
 
-Entry point (`./application run`). Creates and wires all components, registers SIGINT/SIGTERM handlers, and starts the orchestrator loop.
+Entry point (`./application run`). Creates and wires all components, registers SIGINT/SIGTERM handlers, and starts the orchestrator loop. Uses a match expression to create the appropriate tracker (GitHub or Jira) based on config.
 
 ### Orchestrator
 
@@ -38,11 +38,11 @@ The central coordinator. Runs an infinite loop where each tick:
 
 ### TrackerInterface / GitHubTracker / JiraTracker
 
-Abstraction for issue fetching. Each tracker implementation queries its API, paginates results, and maps responses to the normalized `Issue` DTO. Trackers also support fetching states by ID for blocker checks and reconciliation.
+Abstraction for issue fetching. Each tracker implementation queries its API, paginates results, and maps responses to the normalized `Issue` DTO. Trackers also support fetching states by ID for blocker checks and reconciliation. The GitHub tracker auto-creates configured state labels at startup.
 
 ### WorkspaceManager
 
-Manages isolated directories for each issue. Handles creation, hook execution, and cleanup. Includes path traversal protection to prevent workspaces from escaping the root directory.
+Manages git worktrees for each issue. Creates worktrees from the detected base branch (origin/HEAD, main, or master), runs setup commands with `%BASE%` substitution, and handles cleanup. Includes path traversal protection to prevent worktrees from escaping the root directory.
 
 ### PromptBuilder
 
@@ -50,11 +50,11 @@ Renders Twig templates with issue data and retry context. Converts DateTimes to 
 
 ### ClaudeCodeRunner
 
-Launches Claude Code via `proc_open`, manages streaming JSON output parsing, enforces turn and stall timeouts, and supports multi-turn sessions (first turn sends prompt, subsequent turns use `--continue`).
+Launches Claude Code via `proc_open`, manages streaming JSON output parsing, enforces turn and stall timeouts, and supports multi-turn sessions (first turn sends prompt via stdin, subsequent turns use `--continue`). Logs tool use and result events to both the console and structured log.
 
 ### WorkflowLoader
 
-Parses workflow files: splits YAML frontmatter from the Twig prompt template, validates structure. Re-reads the file on each call, enabling live config changes.
+Parses workflow files: splits YAML frontmatter from the Twig prompt template using regex, validates structure. Re-reads the file on each call, enabling live config changes.
 
 ## Data Flow
 
@@ -63,17 +63,19 @@ Parses workflow files: splits YAML frontmatter from the Twig prompt template, va
 3. **Tracker** fetches issues and returns `Issue[]`
 4. **Orchestrator** sorts, filters, and dispatches eligible issues
 5. For each dispatched issue:
-   - **WorkspaceManager** creates directory and runs `after_create` hooks
+   - **WorkspaceManager** creates a git worktree and runs setup commands
    - **PromptBuilder** renders the template with issue data
    - **ClaudeCodeRunner** pipes the prompt to Claude Code and monitors output
 6. Parent process monitors children and handles retries/cleanup
 
 ## Key Design Decisions
 
-**Process isolation via fork**: Each issue runs in a separate child process. This provides natural isolation - a crash in one agent doesn't affect others. The parent never does heavy work, it only coordinates.
+**Process isolation via fork**: Each issue runs in a separate child process via `pcntl_fork`. This provides natural isolation — a crash in one agent doesn't affect others. The parent never does heavy work, it only coordinates.
 
 **Polling over webhooks**: Symphony pulls from the tracker on a timer rather than receiving push events. This simplifies deployment (no public endpoint needed) and makes the system resilient to network interruptions.
 
 **Live config reload**: The workflow file is re-read on every tick. This allows changing concurrency limits, timeouts, or even the prompt template without restarting the daemon.
 
 **Normalized Issue DTO**: Both GitHub and Jira map to the same `Issue` structure. The orchestrator and prompt builder never deal with tracker-specific data.
+
+**Git worktrees for isolation**: Each issue gets its own git worktree rather than a clone, keeping the repo's objects shared while providing branch-level isolation.

--- a/docs/explanation/multi-turn-sessions.md
+++ b/docs/explanation/multi-turn-sessions.md
@@ -1,6 +1,6 @@
 # Multi-turn Agent Sessions
 
-Symphony supports multi-turn Claude Code sessions where an agent can retry within the same workspace if the first attempt fails.
+Symphony supports multi-turn Claude Code sessions where an agent can retry within the same worktree if the first attempt fails.
 
 ## How It Works
 
@@ -9,7 +9,7 @@ Each child process runs an agent session of up to `max_turns` turns:
 ### Turn 1: Initial Prompt
 
 1. Build the full prompt from the Twig template with issue data
-2. Launch Claude Code: `claude -p --output-format stream-json`
+2. Launch Claude Code: `claude -p --verbose --output-format stream-json --dangerously-skip-permissions`
 3. Pipe the rendered prompt to stdin
 4. Parse streaming JSON output for session_id and token usage
 5. Wait for the process to exit
@@ -39,15 +39,15 @@ The number of turns controls how many chances an agent gets within a single disp
 | | Turn | Retry |
 |---|------|-------|
 | **Scope** | Within a single child process | New child process |
-| **Workspace** | Same workspace, preserved state | Same workspace, preserved state |
+| **Worktree** | Same worktree, preserved state | Same worktree, preserved state |
 | **Session** | Continuation (`--continue`) | Fresh prompt (with `attempt` variable) |
-| **Delay** | 1 second | Exponential backoff (10s-300s) |
+| **Delay** | 1 second | Exponential backoff (10s–300s) |
 | **Prompt** | No new prompt | Full prompt re-rendered with `attempt` set |
 
 A typical lifecycle:
 1. Issue dispatched, child process starts
 2. Turn 1 fails (e.g., tests don't pass)
-3. Turns 2-5: continuation attempts, each building on prior work
+3. Turns 2–5: continuation attempts, each building on prior work
 4. If all turns fail, child exits with non-zero code
 5. Parent queues issue for retry with backoff
 6. On retry, a new child process starts with the full prompt (including `{% if attempt %}` block)
@@ -56,8 +56,8 @@ A typical lifecycle:
 
 Each turn has its own timeout enforcement:
 
-- **Turn timeout** (`claude.turn_timeout_ms`): Maximum wall-clock time for a single Claude Code invocation
-- **Stall timeout** (`claude.stall_timeout_ms`): Maximum time without any stdout output
+- **Turn timeout** (`claude.turn_timeout_ms`): Maximum wall-clock time for a single Claude Code invocation (default: 1 hour)
+- **Stall timeout** (`claude.stall_timeout_ms`): Maximum time without any stdout output (default: 5 minutes)
 
 If either timeout fires, the Claude Code process is killed with SIGTERM and the turn counts as failed.
 
@@ -70,6 +70,11 @@ Token usage is accumulated across all turns in a session. The final result inclu
 Claude Code with `--output-format stream-json` emits newline-delimited JSON events. The runner parses these incrementally to extract:
 - `session_id`: Identifies the session for continuation
 - `usage.input_tokens` / `usage.output_tokens`: Token consumption
-- `input_tokens` / `output_tokens`: Alternative top-level token fields
+- Top-level `input_tokens` / `output_tokens`: Alternative token fields
 
-Unrecognized event types are logged at debug level and otherwise ignored.
+The runner also logs agent activity:
+- **Tool use**: Logs tool name and a summary (file path, command, pattern)
+- **Text output**: Logs assistant text (truncated to 200 chars)
+- **Results**: Logs subtype, duration, and cost
+- Known event types (system, user, message, content_block_delta/stop, message_delta/stop, rate_limit_event) are silently ignored
+- Unknown event types are logged as warnings

--- a/docs/explanation/orchestration-loop.md
+++ b/docs/explanation/orchestration-loop.md
@@ -9,11 +9,11 @@ The orchestrator runs an infinite loop where each iteration (called a "tick") pe
 Check the status of all running child processes:
 
 - **Non-blocking wait**: `pcntl_waitpid` with `WNOHANG` checks if each child has exited without blocking
-- **Exit handling**: If a child exited with code 0, mark as success and release the claimed slot. If non-zero, queue for retry with exponential backoff
+- **Exit handling**: If a child exited with code 0, mark as success and keep the issue claimed (preventing re-dispatch until tracker state changes to terminal). If non-zero, queue for retry with exponential backoff
 - **Stall detection**: Compare `hrtime` since last activity against `stall_timeout_ms`. Stalled workers are killed with SIGTERM and queued for retry
 - **State refresh**: For still-running workers, query the tracker for current issue states:
-  - **Terminal state**: Kill the worker and remove the workspace
-  - **Non-active, non-terminal**: Kill the worker but preserve the workspace (the issue may return to active)
+  - **Terminal state**: Kill the worker, remove the worktree, and clear the claimed slot
+  - **Non-active, non-terminal**: Kill the worker, clear the claimed slot, but preserve the worktree (the issue may return to active)
   - **Still active**: No action
 
 ### 2. Config Reload
@@ -27,9 +27,9 @@ Query the tracker for issues in active states. The tracker handles pagination in
 ### 4. Sort
 
 Sort candidates by three keys:
-1. **Priority** ascending (lower number = higher priority, null = lowest)
+1. **Priority** ascending (lower number = higher priority, null = `PHP_INT_MAX`)
 2. **Created date** ascending (older issues first)
-3. **Identifier** ascending (alphabetical tiebreaker)
+3. **Identifier** ascending (string comparison tiebreaker)
 
 This ensures high-priority, older issues are worked on first.
 
@@ -37,7 +37,7 @@ This ensures high-priority, older issues are worked on first.
 
 Remove ineligible issues from the sorted list:
 - **Already running**: Issue has an active child process
-- **Claimed**: Issue was recently dispatched (prevents re-dispatch before the child starts)
+- **Claimed**: Issue was recently completed successfully (stays claimed until terminal)
 - **In retry backoff**: Issue failed and its retry delay hasn't elapsed
 - **Blocked**: Issue has `blockedBy` references to issues that are still in active states
 
@@ -45,7 +45,7 @@ Remove ineligible issues from the sorted list:
 
 For each eligible issue, up to `max_concurrent_agents - running_count`:
 1. `pcntl_fork()` creates a child process
-2. **Child**: creates workspace, runs hooks, renders prompt, launches Claude Code, exits with result code
+2. **Child**: creates worktree, runs setup commands, renders prompt, launches Claude Code, exits with result code
 3. **Parent**: records the child PID, marks the issue as running and claimed
 
 ### 7. Process Retry Queue
@@ -60,7 +60,9 @@ Between ticks, the daemon sleeps for `polling.interval_ms`. The sleep is broken 
 
 ## Startup
 
-Before the first tick, the orchestrator runs `cleanupTerminal`: it scans existing workspace directories, checks their issues' tracker states, and removes workspaces for issues that have moved to terminal states since the last run.
+Before the first tick:
+1. `ensureLabels()` creates any missing state labels on the tracker (GitHub only)
+2. `cleanupTerminal()` scans existing worktree directories, checks their issues' tracker states, and removes worktrees for issues that have moved to terminal states since the last run
 
 ## Shutdown
 

--- a/docs/explanation/process-model.md
+++ b/docs/explanation/process-model.md
@@ -7,7 +7,7 @@ Symphony uses POSIX process forking to run agents in isolated child processes. T
 When the orchestrator dispatches an issue, it calls `pcntl_fork()`:
 
 - **Parent** (fork returns child PID): Records the PID, marks the issue as running and claimed, continues the orchestration loop
-- **Child** (fork returns 0): Runs the full agent workflow (workspace setup, hooks, prompt rendering, Claude Code execution), then calls `exit()` with the result code
+- **Child** (fork returns 0): Runs the full agent workflow (worktree setup, prompt rendering, Claude Code execution), then calls `exit()` with the result code
 
 If `pcntl_fork()` returns -1 (failure), the issue is skipped for this tick.
 
@@ -20,12 +20,13 @@ The parent process never does heavy work. Its role is coordination:
 3. **Detect stalls**: Compares `hrtime()` against last activity timestamps
 4. **Kill misbehaving workers**: `posix_kill($pid, SIGTERM)` for stalled or state-transitioned issues
 5. **Manage retry queue**: Tracks failed issues with exponential backoff timing
+6. **Manage claimed set**: Keeps completed issues claimed to prevent re-dispatch until terminal
 
 ## Child Responsibilities
 
 Each child process:
 
-1. **Create workspace**: `WorkspaceManager::create()` makes the directory and runs `after_create` hooks
+1. **Create worktree**: `WorkspaceManager::create()` creates a git worktree and runs setup commands
 2. **Render prompt**: `PromptBuilder::render()` fills the Twig template with issue data
 3. **Run agent**: `ClaudeCodeRunner::run()` manages the multi-turn session
 4. **Exit**: Code 0 on success, 1 on agent failure, 2 on unhandled exception
@@ -49,7 +50,7 @@ SIGTERM → orchestrator->requestShutdown()
 3. `waitForChildren()` polls all running children every 100ms
 4. Once all children have exited, the parent logs totals and exits with code 0
 
-Children are not explicitly signaled during shutdown - they are allowed to complete naturally. If a child hangs, the parent will wait indefinitely.
+Children are not explicitly signaled during shutdown — they are allowed to complete naturally. If a child hangs, the parent will wait indefinitely.
 
 ## Worker Lifecycle
 
@@ -62,9 +63,9 @@ Eligible issue found
    │         │
 Parent     Child
    │         │
-   │    Create workspace
+   │    Create git worktree
    │         │
-   │    Run after_create hooks
+   │    Run setup commands
    │         │
    │    Render prompt
    │         │
@@ -76,7 +77,7 @@ Parent     Child
 pcntl_waitpid detects exit
         │
         ▼
-  exit code 0? ──yes──▶ Release slot, clear claimed
+  exit code 0? ──yes──▶ Keep claimed, release running slot
         │
         no
         │
@@ -84,17 +85,21 @@ pcntl_waitpid detects exit
   Queue for retry (exponential backoff)
 ```
 
-## Workspace Cleanup
+## Worktree Lifecycle
 
-Workspaces persist across retries - the same directory is reused if the issue is re-dispatched. Cleanup happens when:
+Worktrees persist across retries — the same directory is reused if the issue is re-dispatched. Setup commands only run on initial creation, not on reuse. Cleanup happens when:
 
-- **Terminal state**: Issue moves to a terminal state while a worker is running. The parent kills the worker and calls `WorkspaceManager::remove()`, which runs `before_remove` hooks and recursively deletes the directory.
-- **Startup cleanup**: When the orchestrator starts, `cleanupTerminal()` scans existing workspace directories and removes any whose issues are now in terminal states.
-- **Non-active state**: If an issue moves to a non-active, non-terminal state, the worker is killed but the workspace is preserved (the issue may return to active later).
+- **Terminal state**: Issue moves to a terminal state while a worker is running. The parent kills the worker and calls `WorkspaceManager::remove()`, which removes the worktree and deletes the branch.
+- **Startup cleanup**: When the orchestrator starts, `cleanupTerminal()` prunes stale worktrees and removes any whose issues are now in terminal states.
+- **Non-active state**: If an issue moves to a non-active, non-terminal state, the worker is killed but the worktree is preserved (the issue may return to active later).
+
+## Worktree Path Security
+
+The WorkspaceManager validates that computed workspace paths don't escape the root directory. It uses `realpath()` to resolve symlinks and `str_starts_with()` to ensure the path remains under the configured root. A `RuntimeException` is thrown on path traversal attempts.
 
 ## Resource Limits
 
 Concurrency is bounded by `agent.max_concurrent_agents`. The orchestrator counts running children and only dispatches new ones if slots are available. Each child process consumes:
 - One OS process (fork)
-- One workspace directory on disk
+- One git worktree on disk
 - One Claude Code subprocess (with its own memory footprint)

--- a/docs/how-to/configure-github-tracker.md
+++ b/docs/how-to/configure-github-tracker.md
@@ -56,20 +56,29 @@ tracker:
 
 State matching is case-insensitive. An issue with the label "Todo" matches `todo`.
 
-Issues without any matching label are ignored (neither active nor terminal).
+State determination checks terminal states first, then active states. Issues without any matching label get the state `unknown` and are ignored.
+
+## Label Auto-Creation
+
+At startup, Symphony calls `ensureLabels()` which creates any missing `active_states` and `terminal_states` labels on the GitHub repository. This ensures the configured labels exist before polling begins.
 
 ## How Candidate Issues Are Fetched
 
 The GitHub tracker:
 1. Lists open issues from the repository via the GitHub REST API
 2. Paginates through all results (100 per page)
-3. Maps each issue's labels to determine its state
-4. Returns issues whose state matches one of the `active_states`
+3. Skips pull requests (GitHub's issues endpoint returns both)
+4. Maps each issue's labels to determine its state
+5. Returns issues whose state matches one of the `active_states`
+
+## Issue Identifiers
+
+GitHub issues use the format `{repo}#{number}` as their identifier (e.g., `my-project#42`). Branch names are derived as `symphony/{repo}__{number}` with non-alphanumeric characters replaced by underscores.
 
 ## Blocked Issues
 
-If an issue body or metadata references other issues (via the `blockedBy` field on the Issue DTO), Symphony will check the state of those blocking issues. If any blocker is in an `active_state`, the issue is skipped until the blocker is resolved.
+The tracker parses issue body text for `blocked by #N` patterns (case-insensitive). If any blocking issue is still in an active state, Symphony skips the blocked issue until the blocker resolves.
 
 ## Priority
 
-GitHub issues don't have a native priority field. The tracker extracts priority from labels matching the pattern `priority:<N>` (e.g., `priority:1`). Lower numbers are higher priority. Issues without a priority label default to the lowest priority.
+GitHub issues don't have a native priority field. The tracker extracts priority from labels matching the pattern `priority:<N>` or `priority <N>` (e.g., `priority:1`). Lower numbers are higher priority. Issues without a priority label default to null (sorted last).

--- a/docs/how-to/configure-jira-tracker.md
+++ b/docs/how-to/configure-jira-tracker.md
@@ -7,7 +7,7 @@ Set `tracker.kind` to `jira` in your workflow file:
 ```yaml
 tracker:
   kind: jira
-  endpoint: https://your-domain.atlassian.net
+  endpoint: $JIRA_BASE_URL
   project_slug: PROJ
   email: $JIRA_EMAIL
   api_key: $JIRA_API_TOKEN
@@ -40,20 +40,34 @@ JIRA_API_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxx
 | `tracker.project_slug` | Yes | Jira project key (e.g., `PROJ`) |
 | `tracker.email` | Yes | Email for API authentication |
 | `tracker.api_key` | Yes | Jira API token |
-| `tracker.active_states` | No | States to treat as workable (default: `['To Do', 'In Progress']`) |
-| `tracker.terminal_states` | No | States to treat as finished (default: `['Done', 'Closed', 'Cancelled', 'Canceled', 'Duplicate']`) |
+| `tracker.active_states` | No | States to treat as workable (default: `['Todo', 'In Progress']`) |
+| `tracker.terminal_states` | No | States to treat as finished (default: `['Closed', 'Cancelled', 'Canceled', 'Duplicate', 'Done']`) |
+| `tracker.assignee` | No | Filter by assignee. Default: `currentUser()`. Set to `none` to disable. |
+| `tracker.sprint` | No | Filter by sprint. Default: `openSprints()`. Set to `none` to disable. |
+| `tracker.jql` | No | Custom JQL override. When set, replaces the auto-generated query entirely. |
 
 ## How Candidate Issues Are Fetched
 
-The Jira tracker:
-1. Builds a JQL query: `project = <project_slug> AND status IN (<active_states>)`
-2. Queries the Jira REST API v3 (`/rest/api/3/search`)
-3. Paginates through all results
-4. Maps Jira fields to the normalized Issue DTO
+The Jira tracker builds a JQL query and paginates through results (50 per page).
+
+**Default JQL construction:**
+```
+project = PROJ AND status in ("To Do","In Progress") AND assignee = currentUser() AND sprint in openSprints()
+```
+
+Set `tracker.jql` to override with a fully custom query:
+```yaml
+tracker:
+  jql: "project = PROJ AND labels = symphony AND status != Done"
+```
+
+Set `tracker.assignee: none` or `tracker.sprint: none` to omit those clauses from the default query.
+
+**Fields fetched:** summary, description, status, priority, labels, issuelinks, created, updated.
 
 ## State Mapping
 
-Jira states are matched by the issue's workflow status name (case-insensitive). Use the exact status names from your Jira workflow:
+Jira states are matched by the issue's workflow `status.name` field. Use the exact status names from your Jira workflow:
 
 ```yaml
 tracker:
@@ -68,8 +82,16 @@ tracker:
 
 ## Priority
 
-Jira's native priority field is used directly. The tracker maps Jira priority names to numeric values for sorting (Highest=1, High=2, Medium=3, Low=4, Lowest=5).
+Jira's native `priority.id` field is used directly as a numeric value for sorting.
 
 ## Blocked Issues
 
-The Jira tracker reads the `issuelinks` field to detect blocking relationships. If an issue is blocked by another issue that is in an active state, Symphony skips it until the blocker resolves.
+The Jira tracker reads the `issuelinks` field. Links where `type.name` is "blocks" and an `inwardIssue.key` exists are recorded as blockers. Symphony skips blocked issues until all blockers resolve.
+
+## Description Handling
+
+Jira stores descriptions in Atlassian Document Format (ADF). The tracker recursively walks ADF nodes to extract plain text, adding newlines after block elements (paragraphs, headings, lists).
+
+## Label Management
+
+Unlike the GitHub tracker, the Jira tracker does not manage labels — Jira uses workflow statuses for state tracking, so `ensureLabels()` is a no-op.

--- a/docs/how-to/configure-workspace-hooks.md
+++ b/docs/how-to/configure-workspace-hooks.md
@@ -1,89 +1,81 @@
-# Configure Workspace Hooks
+# Configure Workspace Setup
 
-Workspace hooks run shell commands at specific points in a workspace's lifecycle. Use them to set up repositories, install dependencies, or clean up resources.
-
-## Hook Phases
-
-| Phase | When | Fatal on failure |
-|-------|------|-----------------|
-| `after_create` | After the workspace directory is created | Yes |
-| `before_run` | Before the agent is launched (not yet implemented in dispatch) | Yes |
-| `before_remove` | Before the workspace directory is deleted | No |
-
-Fatal hooks cause the child process to exit with an error if they return a non-zero exit code. Non-fatal hooks log a warning and continue.
+Workspace setup commands run shell commands when a new git worktree is created for an issue. Use them to install dependencies, copy configuration files, or prepare the environment.
 
 ## Configuration
 
-Hooks are arrays of shell commands under `workspace.hooks`:
+Setup commands are an array of shell commands under `workspace.setup`:
 
 ```yaml
 workspace:
-  root: /tmp/symphony_workspaces
-  hooks:
-    after_create:
-      - "git clone https://github.com/owner/repo.git ."
-      - "composer install --no-interaction"
-    before_run:
-      - "git pull origin main"
-    before_remove:
-      - "git stash"
+  setup:
+    - "cp %BASE%/.env .env"
+    - "composer install --no-interaction --no-progress"
 ```
 
-Each command is executed in the workspace directory as the working directory.
+Each command runs in the worktree directory as the working directory.
 
-## Hook Timeout
+## The `%BASE%` Placeholder
 
-All hooks share a single timeout setting:
+Use `%BASE%` in setup commands to reference the main repository root. This is useful for copying files from the base repo into the worktree:
 
 ```yaml
-hooks:
-  timeout_ms: 60000  # 1 minute (default)
+workspace:
+  setup:
+    - "cp %BASE%/.env .env"
+    - "ln -sf %BASE%/vendor vendor"
 ```
 
-If a hook exceeds this timeout, it's killed with SIGTERM.
+## Setup Timeout
+
+Configure how long each setup command is allowed to run:
+
+```yaml
+workspace:
+  setup_timeout_ms: 60000  # 1 minute (default)
+```
+
+If a command exceeds this timeout, it's killed with SIGTERM and the workspace creation fails (fatal — the child process exits with an error).
 
 ## Examples
 
-### Clone and Install Dependencies
+### PHP/Laravel Project
 
 ```yaml
 workspace:
-  hooks:
-    after_create:
-      - "git clone https://github.com/owner/repo.git ."
-      - "npm install"
-    before_run:
-      - "git checkout main"
-      - "git pull origin main"
+  setup:
+    - "cp %BASE%/.env .env"
+    - "composer install --no-interaction --no-progress"
+    - "php artisan key:generate"
+    - "php artisan migrate --force"
 ```
 
-### Clean Up Before Removal
+### Node.js Project
 
 ```yaml
 workspace:
-  hooks:
-    before_remove:
-      - "git push origin --delete $(git branch --show-current) 2>/dev/null || true"
+  setup:
+    - "cp %BASE%/.env .env"
+    - "npm install"
 ```
 
-### Multiple Setup Steps
+### Symlink Shared Dependencies
+
+To avoid reinstalling dependencies in every worktree:
 
 ```yaml
 workspace:
-  hooks:
-    after_create:
-      - "git clone https://github.com/owner/repo.git ."
-      - "cp .env.example .env"
-      - "composer install --no-interaction --no-progress"
-      - "php artisan key:generate"
-      - "php artisan migrate --force"
+  setup:
+    - "ln -sf %BASE%/vendor vendor"
+    - "ln -sf %BASE%/node_modules node_modules"
+    - "cp %BASE%/.env .env"
 ```
 
 ## Behavior Details
 
 - Commands run sequentially in the order listed
 - Each command runs in a separate process via `proc_open`
-- The working directory is the workspace path (e.g., `/tmp/symphony_workspaces/issue-42`)
+- The working directory is the worktree path
 - stdout and stderr are captured; stderr is included in error messages on failure
-- `after_create` hooks run once when the workspace is first created for an issue
-- `before_remove` hooks run before cleanup on terminal state transitions and during startup cleanup of stale workspaces
+- Setup commands only run when a new worktree is created — existing worktrees are reused without re-running setup
+- If any setup command exits with a non-zero code, workspace creation fails and the child process exits with an error

--- a/docs/how-to/tune-retry-and-timeouts.md
+++ b/docs/how-to/tune-retry-and-timeouts.md
@@ -37,16 +37,16 @@ claude:
 
 If Claude Code produces no stdout for this duration, it's considered stalled and killed.
 
-### Hook Timeout
+### Setup Timeout
 
-Maximum time for workspace hooks to complete:
+Maximum time for workspace setup commands to complete:
 
 ```yaml
-hooks:
-  timeout_ms: 60000  # 1 minute (default)
+workspace:
+  setup_timeout_ms: 60000  # 1 minute (default)
 ```
 
-If a hook exceeds this, it's killed. Fatal hooks (`after_create`, `before_run`) cause the child process to fail. Non-fatal hooks (`before_remove`) log a warning and continue.
+If a setup command exceeds this timeout, it's killed with SIGTERM and the workspace creation fails.
 
 ## Retry Backoff
 
@@ -72,7 +72,7 @@ agent:
   max_retry_backoff_ms: 300000  # 5 minutes (default)
 ```
 
-There is no maximum retry count - issues continue retrying until they succeed or their tracker state changes to terminal.
+There is no maximum retry count — issues continue retrying until they succeed or their tracker state changes to terminal.
 
 ## Polling Interval
 

--- a/docs/how-to/write-workflow-templates.md
+++ b/docs/how-to/write-workflow-templates.md
@@ -22,12 +22,12 @@ The YAML section configures the tracker, polling, workspace, agent, and claude s
 | Variable | Type | Description |
 |----------|------|-------------|
 | `issue.id` | string | Internal ID from the tracker |
-| `issue.identifier` | string | Human-readable identifier (e.g., `#42`, `PROJ-123`) |
+| `issue.identifier` | string | Human-readable identifier (e.g., `my-repo#42`, `PROJ-123`) |
 | `issue.title` | string | Issue title |
 | `issue.description` | string | Issue body/description |
 | `issue.priority` | int or null | Numeric priority (lower = higher priority) |
 | `issue.state` | string | Current state label |
-| `issue.branchName` | string | Suggested branch name |
+| `issue.branchName` | string | Git branch name (e.g., `symphony/my-repo__42`) |
 | `issue.url` | string | Web URL for the issue |
 | `issue.labels` | string[] | Lowercase label list |
 | `issue.blockedBy` | string[] | IDs of blocking issues |
@@ -89,7 +89,7 @@ You are an expert software engineer working on {{ issue.identifier }}: {{ issue.
 {% endfor %}
 
 ## Instructions
-- Create a feature branch named `{{ issue.branchName }}`
+- Work on the branch `{{ issue.branchName }}`
 - Write tests for your changes
 - Make small, focused commits
 - Do not modify unrelated files
@@ -119,8 +119,8 @@ This is a bug fix. Write a failing test first, then fix the bug.
 
 ## Tips
 
-- The template uses Twig with `strict_variables: true` - referencing an undefined variable will error
-- Autoescaping is disabled - output is plain text, not HTML
+- The template uses Twig with `strict_variables: true` — referencing an undefined variable will error
+- Autoescaping is disabled — output is plain text, not HTML
 - DateTimes are converted to ISO 8601 strings before rendering
 - Keep prompts focused: the more specific the instructions, the better the agent performs
 - Use `{% if attempt %}` to give retry-specific guidance

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,7 +29,7 @@
 
 | Code | Meaning |
 |------|---------|
-| `0` | Clean shutdown (via SIGINT/SIGTERM or all work complete) |
+| `0` | Clean shutdown (via SIGINT/SIGTERM) |
 | `1` | Startup failure (workflow file not found, invalid config, tracker creation failed) |
 
 Child processes (forked per issue) use these exit codes:
@@ -55,14 +55,32 @@ The shutdown sequence:
 5. Logs final token usage totals
 6. Exits with code 0
 
+## Console Output
+
+Symphony writes user-friendly output to stdout:
+
+```
+Symphony starting (github tracker)
+  Workflow: WORKFLOW.md
+  Log file: /path/to/symphony.log
+  Press Ctrl+C to stop
+Symphony orchestrator started
+  Polling every 30000ms, max 10 concurrent agents
+  Dispatching my-repo#42: Fix the login bug
+    Edit app/Auth/LoginController.php
+    Bash php artisan test --filter=LoginTest
+    Result: success (45.2s, $0.1234)
+  Completed my-repo#42
+```
+
 ## Logging
 
-All log output goes to stderr in structured `key=value` format:
+Structured log output goes to `symphony.log` in `key=value` format:
 
 ```
 ts=2026-03-30T12:00:00Z level=INFO msg="Symphony starting" workflow=WORKFLOW.md tracker=github
-ts=2026-03-30T12:00:00Z level=INFO msg="Dispatching issue" issue_id=42 issue_identifier="#42"
+ts=2026-03-30T12:00:00Z level=INFO msg="Dispatching issue" issue_id=42 issue_identifier="my-repo#42"
 ts=2026-03-30T12:00:00Z level=ERROR msg="Turn timeout reached" elapsed_ms=3600001 timeout_ms=3600000
 ```
 
-Sensitive values (API keys, tokens) are redacted from log output.
+Sensitive values (API keys, tokens, passwords, secrets) are automatically redacted from log output.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2,18 +2,21 @@
 
 Workflow files use YAML frontmatter to configure Symphony. All keys below are set in the YAML section between `---` delimiters.
 
-String values support environment variable substitution: `$VAR` or `${VAR}`.
+String values support environment variable substitution: `$VAR` or `${VAR}`. An error is thrown at startup if a referenced variable is not set.
 
 ## tracker
 
 | Key | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
-| `tracker.kind` | string | Yes | - | Tracker type: `github` or `jira` |
-| `tracker.api_key` | string | Yes | - | API authentication token |
-| `tracker.repository` | string | GitHub only | - | GitHub `owner/repo` |
-| `tracker.endpoint` | string | Jira only | - | Jira Cloud base URL |
-| `tracker.project_slug` | string | Jira only | - | Jira project key (e.g., `PROJ`) |
-| `tracker.email` | string | Jira only | - | Email for Jira API auth |
+| `tracker.kind` | string | Yes | — | Tracker type: `github` or `jira` |
+| `tracker.api_key` | string | Yes | — | API authentication token |
+| `tracker.repository` | string | GitHub only | — | GitHub `owner/repo` |
+| `tracker.endpoint` | string | Jira only | — | Jira Cloud base URL |
+| `tracker.project_slug` | string | Jira only | — | Jira project key (e.g., `PROJ`) |
+| `tracker.email` | string | Jira only | — | Email for Jira API auth |
+| `tracker.assignee` | string | Jira only | `currentUser()` | Jira assignee filter. Set to `none` to disable. |
+| `tracker.sprint` | string | Jira only | `openSprints()` | Jira sprint filter. Set to `none` to disable. |
+| `tracker.jql` | string | Jira only | — | Custom JQL override. Replaces the auto-generated query. |
 | `tracker.active_states` | string[] | No | `['Todo', 'In Progress']` | Issue states to treat as workable |
 | `tracker.terminal_states` | string[] | No | `['Closed', 'Cancelled', 'Canceled', 'Duplicate', 'Done']` | Issue states to treat as finished |
 
@@ -27,16 +30,9 @@ String values support environment variable substitution: `$VAR` or `${VAR}`.
 
 | Key | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
-| `workspace.root` | string | No | `<sys_temp_dir>/symphony_workspaces` | Base directory for issue workspaces |
-| `workspace.hooks.after_create` | string[] | No | `[]` | Commands to run after creating a workspace |
-| `workspace.hooks.before_run` | string[] | No | `[]` | Commands to run before launching the agent |
-| `workspace.hooks.before_remove` | string[] | No | `[]` | Commands to run before deleting a workspace |
-
-## hooks
-
-| Key | Type | Required | Default | Description |
-|-----|------|----------|---------|-------------|
-| `hooks.timeout_ms` | int | No | `60000` | Maximum time (ms) for each hook command |
+| `workspace.root` | string | No | `<repo_root>/.symphony/worktrees` | Base directory for issue worktrees |
+| `workspace.setup` | string[] | No | `[]` | Shell commands to run after creating a new worktree. Supports `%BASE%` placeholder for repo root. |
+| `workspace.setup_timeout_ms` | int | No | `60000` | Maximum time (ms) for each setup command |
 
 ## agent
 
@@ -52,7 +48,7 @@ The entire `claude` section is optional. Sensible defaults are provided.
 
 | Key | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
-| `claude.command` | string | No | `claude -p --output-format stream-json --worktree` | Claude Code CLI command |
+| `claude.command` | string | No | `claude -p --verbose --output-format stream-json --dangerously-skip-permissions` | Claude Code CLI command |
 | `claude.turn_timeout_ms` | int | No | `3600000` | Maximum wall-clock time per turn (ms) |
 | `claude.stall_timeout_ms` | int | No | `300000` | Maximum time without output before killing (ms) |
 
@@ -75,9 +71,19 @@ tracker:
 polling:
   interval_ms: 30000
 
+workspace:
+  setup:
+    - "cp %BASE%/.env .env"
+    - "composer install --no-interaction --no-progress"
+  setup_timeout_ms: 120000
+
 agent:
   max_concurrent_agents: 5
   max_turns: 20
   max_retry_backoff_ms: 300000
+
+claude:
+  turn_timeout_ms: 3600000
+  stall_timeout_ms: 300000
 ---
 ```

--- a/docs/reference/issue-dto.md
+++ b/docs/reference/issue-dto.md
@@ -7,17 +7,19 @@ The `Issue` class (`App\Tracker\Issue`) is the normalized data transfer object u
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | `string` | Internal issue ID from the tracker (GitHub issue number as string, Jira issue ID) |
-| `identifier` | `string` | Human-readable identifier (e.g., `#42` for GitHub, `PROJ-123` for Jira) |
+| `identifier` | `string` | Human-readable identifier (e.g., `my-repo#42` for GitHub, `PROJ-123` for Jira) |
 | `title` | `string` | Issue title / summary |
 | `description` | `string` | Issue body / description text |
 | `priority` | `?int` | Numeric priority (lower = higher priority). Null if no priority set. |
-| `state` | `string` | Current state label (e.g., `todo`, `In Progress`) |
-| `branchName` | `string` | Suggested git branch name derived from the issue |
+| `state` | `string` | Current state (e.g., `todo`, `In Progress`) |
+| `branchName` | `string` | Git branch name (e.g., `symphony/my-repo__42`) |
 | `url` | `string` | Web URL to view the issue in the browser |
 | `labels` | `string[]` | Array of labels, normalized to lowercase |
-| `blockedBy` | `string[]` | Array of issue IDs that block this issue |
+| `blockedBy` | `string[]` | Array of issue IDs/keys that block this issue |
 | `createdAt` | `DateTimeImmutable` | Creation timestamp, normalized to UTC |
 | `updatedAt` | `DateTimeImmutable` | Last update timestamp, normalized to UTC |
+
+All properties are `readonly`.
 
 ## Template Access
 
@@ -41,15 +43,15 @@ The `toArray()` method returns all fields as an associative array. This is the a
 | Issue Field | GitHub API Source |
 |-------------|-------------------|
 | `id` | Issue number (as string) |
-| `identifier` | `#<number>` |
+| `identifier` | `{repo}#{number}` |
 | `title` | `title` |
 | `description` | `body` |
-| `priority` | Extracted from `priority:<N>` labels |
-| `state` | First matching label from active/terminal states |
-| `branchName` | Derived from identifier and title |
+| `priority` | Extracted from `priority:<N>` or `priority <N>` labels |
+| `state` | First matching label from terminal states, then active states |
+| `branchName` | `symphony/{sanitized identifier}` (non-alphanumeric → `_`) |
 | `url` | `html_url` |
 | `labels` | Label names, lowercased |
-| `blockedBy` | Extracted from issue body/links |
+| `blockedBy` | Extracted from `blocked by #N` patterns in issue body |
 | `createdAt` | `created_at` |
 | `updatedAt` | `updated_at` |
 
@@ -60,12 +62,12 @@ The `toArray()` method returns all fields as an associative array. This is the a
 | `id` | `id` |
 | `identifier` | `key` (e.g., `PROJ-123`) |
 | `title` | `fields.summary` |
-| `description` | `fields.description` (rendered to text) |
-| `priority` | `fields.priority.id` mapped to numeric |
+| `description` | `fields.description` (ADF rendered to plain text) |
+| `priority` | `fields.priority.id` as integer |
 | `state` | `fields.status.name` |
-| `branchName` | Derived from key and summary |
-| `url` | Constructed from endpoint + key |
+| `branchName` | `symphony/{sanitized key}` (non-alphanumeric → `_`) |
+| `url` | `self` (API URL) |
 | `labels` | `fields.labels`, lowercased |
-| `blockedBy` | From `fields.issuelinks` (blocking relationships) |
+| `blockedBy` | From `fields.issuelinks` where type is "blocks" with `inwardIssue.key` |
 | `createdAt` | `fields.created` |
 | `updatedAt` | `fields.updated` |

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -51,6 +51,10 @@ tracker:
 polling:
   interval_ms: 30000
 
+workspace:
+  setup:
+    - "cp %BASE%/.env .env"
+
 agent:
   max_concurrent_agents: 5
   max_turns: 20
@@ -66,8 +70,8 @@ This is retry attempt {{ attempt }}. Review what was done previously and continu
 ```
 
 Key things to change:
-- `tracker.repository` - your GitHub `owner/repo`
-- `active_states` - the issue labels/states that Symphony should pick up (case-insensitive)
+- `tracker.repository` — your GitHub `owner/repo`
+- `active_states` — the issue labels/states that Symphony should pick up (case-insensitive)
 
 ## Step 4: Create a Test Issue
 
@@ -79,13 +83,16 @@ Create an issue on your GitHub repository. Make sure it has a label that matches
 ./application run WORKFLOW.md
 ```
 
-You'll see structured log output on stderr:
+You'll see console output and structured logs:
 
 ```
-ts=2026-03-30T12:00:00Z level=INFO msg="Symphony starting" workflow=WORKFLOW.md tracker=github
-ts=2026-03-30T12:00:00Z level=INFO msg="Orchestrator starting"
-ts=2026-03-30T12:00:00Z level=INFO msg="Dispatching issue" issue_id=1 issue_identifier="#1"
-ts=2026-03-30T12:00:00Z level=INFO msg="Starting agent turn" turn=1 max_turns=20 continuation=false
+Symphony starting (github tracker)
+  Workflow: WORKFLOW.md
+  Log file: /path/to/symphony.log
+  Press Ctrl+C to stop
+Symphony orchestrator started
+  Polling every 30000ms, max 5 concurrent agents
+  Dispatching my-repo#1: Fix the login bug
 ```
 
 ## Step 6: Stop the Daemon
@@ -104,12 +111,15 @@ kill $(pgrep -f "application run")
 ## What Happens Under the Hood
 
 1. Symphony reads `WORKFLOW.md` and resolves environment variables (`$GITHUB_TOKEN` becomes your actual token)
-2. On each tick (every 30 seconds by default), it queries the GitHub API for issues matching `active_states`
-3. For each eligible issue, it forks a child process that:
+2. Configured state labels are auto-created on the GitHub repository if missing
+3. On each tick (every 30 seconds by default), it queries the GitHub API for issues matching `active_states`
+4. For each eligible issue, it forks a child process that:
+   - Creates a git worktree for isolation
+   - Runs workspace setup commands (e.g., copying `.env`)
    - Renders the Twig prompt template with issue data
-   - Launches `claude -p --output-format stream-json --worktree`, which creates a git worktree for isolation
+   - Launches Claude Code with the rendered prompt
    - If the agent fails, retries with `--continue` up to `max_turns` times
-4. The parent process monitors children, kills stalled workers, and retries failed issues with exponential backoff
+5. The parent process monitors children, kills stalled workers, and retries failed issues with exponential backoff
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- Rewrote all 15 docs files to reflect recent codebase changes
- **Workspace hooks → setup commands**: Replaced `workspace.hooks.after_create/before_run/before_remove` with `workspace.setup` array and `%BASE%` placeholder
- **Jira tracker**: Added `tracker.assignee`, `tracker.sprint`, and `tracker.jql` config documentation
- **GitHub tracker**: Documented label auto-creation and correct `{repo}#{number}` identifier format
- **Claude defaults**: Updated command from `--worktree` to `--verbose --dangerously-skip-permissions`
- **Configuration reference**: Added all missing keys, corrected defaults

## Test plan
- [x] All 60 tests pass
- [ ] Review rendered docs for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)