### PR TITLE
Add web UI for monitoring and managing the orchestrator

### DIFF
--- a/app/Commands/RunCommand.php
+++ b/app/Commands/RunCommand.php
@@ -6,6 +6,7 @@ use App\Agent\ClaudeCodeRunner;
 use App\Config\WorkflowConfig;
 use App\Orchestrator\Orchestrator;
 use App\Prompt\PromptBuilder;
+use App\State\StateStore;
 use App\Tracker\GitHubTracker;
 use App\Tracker\JiraTracker;
 use App\Tracker\TrackerInterface;
@@ -47,11 +48,12 @@ class RunCommand extends Command
             $workspace = new WorkspaceManager($config, $logger);
             $promptBuilder = new PromptBuilder;
             $agentRunner = new ClaudeCodeRunner($config, $logger, $this->output);
+            $stateStore = new StateStore;
 
             // Create orchestrator
             $orchestrator = new Orchestrator(
                 $config, $tracker, $workspace, $promptBuilder,
-                $agentRunner, $loader, $logger, $this->output
+                $agentRunner, $loader, $logger, $this->output, $stateStore
             );
 
             // Register signal handlers

--- a/app/Commands/ServeCommand.php
+++ b/app/Commands/ServeCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands;
+
+use LaravelZero\Framework\Commands\Command;
+
+class ServeCommand extends Command
+{
+    protected $signature = 'serve {--host=127.0.0.1 : The host address} {--port=8085 : The port} {--state-db= : Path to state SQLite database}';
+
+    protected $description = 'Start the Symphony web UI server';
+
+    public function handle(): int
+    {
+        $host = $this->option('host');
+        $port = $this->option('port');
+        $publicPath = $this->getPublicPath();
+
+        if (! is_dir($publicPath)) {
+            $this->error("Public directory not found: {$publicPath}");
+
+            return 1;
+        }
+
+        $stateDb = $this->option('state-db') ?: getcwd().'/.symphony/state.sqlite';
+
+        $this->info("Symphony Web UI starting on http://{$host}:{$port}");
+        $this->line("  State database: {$stateDb}");
+        $this->line("  Document root:  {$publicPath}");
+        $this->line('  Press Ctrl+C to stop');
+
+        $env = [
+            'SYMPHONY_STATE_DB' => $stateDb,
+            'SYMPHONY_LOG_PATH' => $this->getLogPath(),
+            'SYMPHONY_WORKFLOW_PATH' => getcwd().'/workflow.yml',
+        ];
+
+        $envFlags = '';
+        foreach ($env as $key => $value) {
+            $envFlags .= " -d {$key}={$value}";
+        }
+
+        $command = sprintf(
+            'php -S %s:%s -t %s %s/router.php%s',
+            $host,
+            $port,
+            escapeshellarg($publicPath),
+            escapeshellarg($publicPath),
+            $envFlags
+        );
+
+        passthru($command, $exitCode);
+
+        return $exitCode;
+    }
+
+    private function getPublicPath(): string
+    {
+        // When running as phar, extract path differently
+        if (\Phar::running()) {
+            return dirname(\Phar::running(false)).'/public';
+        }
+
+        return base_path('public');
+    }
+
+    private function getLogPath(): string
+    {
+        if (\Phar::running()) {
+            return dirname(\Phar::running(false)).'/symphony.log';
+        }
+
+        return getcwd().'/symphony.log';
+    }
+}

--- a/app/Http/ApiHandler.php
+++ b/app/Http/ApiHandler.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Lightweight API handler for the Symphony Web UI.
+ *
+ * Runs inside PHP's built-in web server (no framework bootstrap needed).
+ * Reads state from the shared SQLite database written by the Orchestrator.
+ */
+
+// Autoload is needed for StateStore
+require_once __DIR__.'/../../vendor/autoload.php';
+
+use App\State\StateStore;
+use Symfony\Component\Yaml\Yaml;
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, PUT, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$method = $_SERVER['REQUEST_METHOD'];
+
+$stateDbPath = ini_get('SYMPHONY_STATE_DB') ?: (getcwd().'/.symphony/state.sqlite');
+$logPath = ini_get('SYMPHONY_LOG_PATH') ?: (getcwd().'/symphony.log');
+$workflowPath = ini_get('SYMPHONY_WORKFLOW_PATH') ?: (getcwd().'/workflow.yml');
+
+try {
+    $store = new StateStore($stateDbPath);
+} catch (Throwable $e) {
+    http_response_code(503);
+    echo json_encode(['error' => 'State database not available: '.$e->getMessage()]);
+    exit;
+}
+
+try {
+    match (true) {
+        $uri === '/api/status' && $method === 'GET' => handleStatus($store),
+        $uri === '/api/agents' && $method === 'GET' => handleAgents($store),
+        $uri === '/api/queue' && $method === 'GET' => handleQueue($store),
+        $uri === '/api/tokens' && $method === 'GET' => handleTokens($store),
+        $uri === '/api/logs' && $method === 'GET' => handleLogs($logPath),
+        $uri === '/api/config' && $method === 'GET' => handleConfigGet($workflowPath),
+        $uri === '/api/config' && $method === 'PUT' => handleConfigPut($workflowPath),
+        $uri === '/api/control' && $method === 'POST' => handleControl($store, $workflowPath),
+        default => notFound(),
+    };
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+
+function handleStatus(StateStore $store): void
+{
+    $daemon = $store->getDaemonStatus();
+    $agents = $store->getAgents();
+
+    // Check if daemon is actually alive (heartbeat within last 120s)
+    $isAlive = false;
+    if ($daemon['status'] === 'running' && $daemon['pid']) {
+        $isAlive = posix_kill((int) $daemon['pid'], 0);
+    }
+
+    echo json_encode([
+        'status' => $isAlive ? 'running' : 'stopped',
+        'pid' => $daemon['pid'],
+        'started_at' => $daemon['started_at'],
+        'updated_at' => $daemon['updated_at'],
+        'workflow_path' => $daemon['workflow_path'],
+        'agent_count' => count($agents),
+    ]);
+}
+
+function handleAgents(StateStore $store): void
+{
+    $agents = $store->getAgents();
+    $now = hrtime(true);
+
+    foreach ($agents as &$agent) {
+        $elapsed = ($now - (int) $agent['started_at']) / 1_000_000_000;
+        $agent['elapsed_seconds'] = round($elapsed, 1);
+    }
+
+    echo json_encode(['agents' => $agents]);
+}
+
+function handleQueue(StateStore $store): void
+{
+    $claimed = $store->getClaimed();
+    $retryQueue = $store->getRetryQueue();
+    $now = hrtime(true);
+
+    foreach ($retryQueue as &$entry) {
+        $remaining = ((int) $entry['due_at'] - $now) / 1_000_000_000;
+        $entry['remaining_seconds'] = max(0, round($remaining, 1));
+    }
+
+    echo json_encode([
+        'claimed' => $claimed,
+        'retry_queue' => $retryQueue,
+    ]);
+}
+
+function handleTokens(StateStore $store): void
+{
+    $totals = $store->getTokenTotals();
+
+    // Estimate cost: Claude Opus pricing (approximate)
+    $inputCost = ((int) $totals['input_tokens'] / 1_000_000) * 15.0;
+    $outputCost = ((int) $totals['output_tokens'] / 1_000_000) * 75.0;
+
+    echo json_encode([
+        'input_tokens' => (int) $totals['input_tokens'],
+        'output_tokens' => (int) $totals['output_tokens'],
+        'total_tokens' => (int) $totals['input_tokens'] + (int) $totals['output_tokens'],
+        'seconds' => (float) $totals['seconds'],
+        'estimated_cost_usd' => round($inputCost + $outputCost, 4),
+    ]);
+}
+
+function handleLogs(string $logPath): void
+{
+    $lines = (int) ($_GET['lines'] ?? 100);
+    $since = $_GET['since'] ?? null;
+    $lines = min($lines, 1000);
+
+    if (! file_exists($logPath)) {
+        echo json_encode(['logs' => [], 'file' => $logPath, 'exists' => false]);
+
+        return;
+    }
+
+    $output = [];
+    $exitCode = 0;
+    exec(sprintf('tail -n %d %s', $lines, escapeshellarg($logPath)), $output, $exitCode);
+
+    $logs = [];
+    foreach ($output as $line) {
+        if ($since !== null) {
+            // Basic timestamp filtering: structured logs start with timestamp=...
+            if (preg_match('/^timestamp=(\S+)/', $line, $m)) {
+                if (strcmp($m[1], $since) <= 0) {
+                    continue;
+                }
+            }
+        }
+        $logs[] = $line;
+    }
+
+    $lastTimestamp = null;
+    if (! empty($logs)) {
+        $lastLine = end($logs);
+        if (preg_match('/^timestamp=(\S+)/', $lastLine, $m)) {
+            $lastTimestamp = $m[1];
+        }
+    }
+
+    echo json_encode([
+        'logs' => $logs,
+        'count' => count($logs),
+        'last_timestamp' => $lastTimestamp,
+    ]);
+}
+
+function handleConfigGet(string $workflowPath): void
+{
+    if (! file_exists($workflowPath)) {
+        echo json_encode(['exists' => false, 'path' => $workflowPath, 'content' => '']);
+
+        return;
+    }
+
+    echo json_encode([
+        'exists' => true,
+        'path' => $workflowPath,
+        'content' => file_get_contents($workflowPath),
+    ]);
+}
+
+function handleConfigPut(string $workflowPath): void
+{
+    $input = json_decode(file_get_contents('php://input'), true);
+    if (! isset($input['content'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Missing "content" field']);
+
+        return;
+    }
+
+    // Validate YAML syntax before saving
+    try {
+        Yaml::parse($input['content']);
+    } catch (Throwable $e) {
+        http_response_code(422);
+        echo json_encode(['error' => 'Invalid YAML: '.$e->getMessage()]);
+
+        return;
+    }
+
+    // Backup current file
+    if (file_exists($workflowPath)) {
+        copy($workflowPath, $workflowPath.'.bak');
+    }
+
+    file_put_contents($workflowPath, $input['content']);
+
+    echo json_encode(['saved' => true, 'path' => $workflowPath]);
+}
+
+function handleControl(StateStore $store, string $workflowPath): void
+{
+    $input = json_decode(file_get_contents('php://input'), true);
+    $action = $input['action'] ?? '';
+
+    match ($action) {
+        'stop' => controlStop($store),
+        'start' => controlStart($workflowPath),
+        default => (function () use ($action) {
+            http_response_code(400);
+            echo json_encode(['error' => "Unknown action: {$action}"]);
+        })(),
+    };
+}
+
+function controlStop(StateStore $store): void
+{
+    $daemon = $store->getDaemonStatus();
+    if (! $daemon['pid'] || $daemon['status'] !== 'running') {
+        http_response_code(409);
+        echo json_encode(['error' => 'Daemon is not running']);
+
+        return;
+    }
+
+    $pid = (int) $daemon['pid'];
+    if (! posix_kill($pid, 0)) {
+        $store->markStopped();
+        http_response_code(409);
+        echo json_encode(['error' => 'Daemon process not found, marking as stopped']);
+
+        return;
+    }
+
+    posix_kill($pid, SIGTERM);
+    echo json_encode(['sent' => 'SIGTERM', 'pid' => $pid]);
+}
+
+function controlStart(string $workflowPath): void
+{
+    if (! file_exists($workflowPath)) {
+        http_response_code(404);
+        echo json_encode(['error' => "Workflow file not found: {$workflowPath}"]);
+
+        return;
+    }
+
+    // Determine the application path
+    $appPath = realpath(__DIR__.'/../../application');
+    if (! $appPath) {
+        http_response_code(500);
+        echo json_encode(['error' => 'Cannot locate application binary']);
+
+        return;
+    }
+
+    $cmd = sprintf(
+        'nohup php %s run %s > /dev/null 2>&1 & echo $!',
+        escapeshellarg($appPath),
+        escapeshellarg($workflowPath)
+    );
+
+    $pid = trim((string) shell_exec($cmd));
+
+    echo json_encode(['started' => true, 'pid' => (int) $pid]);
+}
+
+function notFound(): void
+{
+    http_response_code(404);
+    echo json_encode(['error' => 'Not found']);
+}

--- a/app/Orchestrator/Orchestrator.php
+++ b/app/Orchestrator/Orchestrator.php
@@ -6,6 +6,7 @@ use App\Agent\ClaudeCodeRunner;
 use App\Config\StageConfig;
 use App\Config\WorkflowConfig;
 use App\Prompt\PromptBuilder;
+use App\State\StateStore;
 use App\Tracker\Issue;
 use App\Tracker\TrackerInterface;
 use App\Workflow\WorkflowLoader;
@@ -38,6 +39,7 @@ class Orchestrator
         private WorkflowLoader $workflowLoader,
         private LoggerInterface $logger,
         private ?OutputInterface $output = null,
+        private ?StateStore $stateStore = null,
     ) {}
 
     private function console(string $message): void
@@ -77,14 +79,18 @@ class Orchestrator
         // Startup cleanup
         $this->workspace->cleanupTerminal($this->tracker);
 
+        $this->stateStore?->markRunning(getmypid(), '');
+
         while (! $this->shutdown) {
             $this->tick();
+            $this->flushState();
 
             $sleepMs = $this->config->pollingIntervalMs();
             $this->sleepMs($sleepMs);
         }
 
         $this->waitForChildren();
+        $this->stateStore?->markStopped();
         $this->console('<info>Symphony stopped</info>');
         $this->logger->info('Orchestrator stopped', ['totals' => $this->claudeTotals]);
     }
@@ -459,6 +465,22 @@ class Orchestrator
             if (! empty($this->running)) {
                 usleep(100000); // 100ms
             }
+        }
+    }
+
+    private function flushState(): void
+    {
+        try {
+            $this->stateStore?->flush(
+                $this->running,
+                $this->claimed,
+                $this->retryQueue,
+                $this->claudeTotals
+            );
+        } catch (\Throwable $e) {
+            $this->logger->warning('Failed to flush state to store', [
+                'error' => $e->getMessage(),
+            ]);
         }
     }
 

--- a/app/State/StateStore.php
+++ b/app/State/StateStore.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use App\Config\StageConfig;
+use App\Tracker\Issue;
+use PDO;
+
+class StateStore
+{
+    private PDO $db;
+
+    public function __construct(?string $dbPath = null)
+    {
+        $dbPath ??= $this->defaultPath();
+        $dir = dirname($dbPath);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $this->db = new PDO("sqlite:{$dbPath}", null, null, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]);
+
+        $this->db->exec('PRAGMA journal_mode=WAL');
+        $this->migrate();
+    }
+
+    private function defaultPath(): string
+    {
+        $root = getcwd();
+
+        return $root.'/.symphony/state.sqlite';
+    }
+
+    private function migrate(): void
+    {
+        $this->db->exec('
+            CREATE TABLE IF NOT EXISTS daemon (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                pid INTEGER,
+                status TEXT NOT NULL DEFAULT "stopped",
+                started_at TEXT,
+                updated_at TEXT,
+                workflow_path TEXT
+            )
+        ');
+
+        $this->db->exec('
+            CREATE TABLE IF NOT EXISTS agents (
+                issue_id TEXT PRIMARY KEY,
+                pid INTEGER NOT NULL,
+                issue_identifier TEXT NOT NULL,
+                issue_title TEXT NOT NULL,
+                issue_url TEXT NOT NULL,
+                stage TEXT,
+                started_at INTEGER NOT NULL
+            )
+        ');
+
+        $this->db->exec('
+            CREATE TABLE IF NOT EXISTS claimed (
+                claim_key TEXT PRIMARY KEY
+            )
+        ');
+
+        $this->db->exec('
+            CREATE TABLE IF NOT EXISTS retry_queue (
+                issue_id TEXT PRIMARY KEY,
+                attempt INTEGER NOT NULL,
+                due_at INTEGER NOT NULL,
+                error TEXT NOT NULL
+            )
+        ');
+
+        $this->db->exec('
+            CREATE TABLE IF NOT EXISTS token_totals (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                seconds REAL NOT NULL DEFAULT 0
+            )
+        ');
+
+        // Seed singleton rows if absent
+        $this->db->exec("INSERT OR IGNORE INTO daemon (id, status) VALUES (1, 'stopped')");
+        $this->db->exec('INSERT OR IGNORE INTO token_totals (id, input_tokens, output_tokens, seconds) VALUES (1, 0, 0, 0)');
+    }
+
+    // --- Daemon lifecycle ---
+
+    public function markRunning(int $pid, string $workflowPath): void
+    {
+        $now = date('c');
+        $this->db->prepare(
+            'UPDATE daemon SET pid = ?, status = "running", started_at = ?, updated_at = ?, workflow_path = ? WHERE id = 1'
+        )->execute([$pid, $now, $now, $workflowPath]);
+    }
+
+    public function markStopped(): void
+    {
+        $this->db->prepare(
+            'UPDATE daemon SET status = "stopped", updated_at = ? WHERE id = 1'
+        )->execute([date('c')]);
+    }
+
+    public function heartbeat(): void
+    {
+        $this->db->prepare(
+            'UPDATE daemon SET updated_at = ? WHERE id = 1'
+        )->execute([date('c')]);
+    }
+
+    public function getDaemonStatus(): array
+    {
+        return $this->db->query('SELECT * FROM daemon WHERE id = 1')->fetch() ?: [
+            'status' => 'stopped',
+            'pid' => null,
+        ];
+    }
+
+    // --- Agent state ---
+
+    /**
+     * @param  array<string, array{pid: int, issue: Issue, stage: ?StageConfig, startedAt: int}>  $running
+     */
+    public function syncAgents(array $running): void
+    {
+        $this->db->exec('DELETE FROM agents');
+        $stmt = $this->db->prepare(
+            'INSERT INTO agents (issue_id, pid, issue_identifier, issue_title, issue_url, stage, started_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+        );
+
+        foreach ($running as $issueId => $worker) {
+            $stmt->execute([
+                $issueId,
+                $worker['pid'],
+                $worker['issue']->identifier,
+                $worker['issue']->title,
+                $worker['issue']->url,
+                $worker['stage']?->name,
+                $worker['startedAt'],
+            ]);
+        }
+    }
+
+    public function getAgents(): array
+    {
+        return $this->db->query('SELECT * FROM agents ORDER BY started_at ASC')->fetchAll();
+    }
+
+    // --- Claimed ---
+
+    /**
+     * @param  array<string, true>  $claimed
+     */
+    public function syncClaimed(array $claimed): void
+    {
+        $this->db->exec('DELETE FROM claimed');
+        $stmt = $this->db->prepare('INSERT INTO claimed (claim_key) VALUES (?)');
+        foreach (array_keys($claimed) as $key) {
+            $stmt->execute([$key]);
+        }
+    }
+
+    public function getClaimed(): array
+    {
+        return array_column(
+            $this->db->query('SELECT claim_key FROM claimed')->fetchAll(),
+            'claim_key'
+        );
+    }
+
+    // --- Retry queue ---
+
+    /**
+     * @param  array<string, array{attempt: int, dueAt: int, error: string}>  $retryQueue
+     */
+    public function syncRetryQueue(array $retryQueue): void
+    {
+        $this->db->exec('DELETE FROM retry_queue');
+        $stmt = $this->db->prepare(
+            'INSERT INTO retry_queue (issue_id, attempt, due_at, error) VALUES (?, ?, ?, ?)'
+        );
+        foreach ($retryQueue as $issueId => $entry) {
+            $stmt->execute([
+                $issueId,
+                $entry['attempt'],
+                $entry['dueAt'],
+                $entry['error'],
+            ]);
+        }
+    }
+
+    public function getRetryQueue(): array
+    {
+        return $this->db->query('SELECT * FROM retry_queue ORDER BY due_at ASC')->fetchAll();
+    }
+
+    // --- Token totals ---
+
+    /**
+     * @param  array{input_tokens: int, output_tokens: int, seconds: float}  $totals
+     */
+    public function syncTokenTotals(array $totals): void
+    {
+        $this->db->prepare(
+            'UPDATE token_totals SET input_tokens = ?, output_tokens = ?, seconds = ? WHERE id = 1'
+        )->execute([
+            $totals['input_tokens'],
+            $totals['output_tokens'],
+            $totals['seconds'],
+        ]);
+    }
+
+    public function getTokenTotals(): array
+    {
+        return $this->db->query('SELECT input_tokens, output_tokens, seconds FROM token_totals WHERE id = 1')->fetch() ?: [
+            'input_tokens' => 0,
+            'output_tokens' => 0,
+            'seconds' => 0,
+        ];
+    }
+
+    // --- Flush all orchestrator state in one call ---
+
+    public function flush(array $running, array $claimed, array $retryQueue, array $claudeTotals): void
+    {
+        $this->db->beginTransaction();
+        try {
+            $this->syncAgents($running);
+            $this->syncClaimed($claimed);
+            $this->syncRetryQueue($retryQueue);
+            $this->syncTokenTotals($claudeTotals);
+            $this->heartbeat();
+            $this->db->commit();
+        } catch (\Throwable $e) {
+            $this->db->rollBack();
+            throw $e;
+        }
+    }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,185 @@
+function dashboard() {
+    return {
+        // State
+        status: { status: 'unknown', pid: null },
+        agents: [],
+        claimed: [],
+        retryQueue: [],
+        tokens: { input_tokens: 0, output_tokens: 0, estimated_cost_usd: 0 },
+        logs: [],
+        lastTimestamp: null,
+        configContent: '',
+        configError: '',
+        configSaved: false,
+
+        // UI state
+        queueTab: 'claimed',
+        autoScroll: true,
+        controlling: false,
+        savingConfig: false,
+        pollInterval: null,
+        logPollInterval: null,
+
+        init() {
+            this.fetchAll();
+            this.loadConfig();
+
+            // Poll state every 5 seconds
+            this.pollInterval = setInterval(() => this.fetchAll(), 5000);
+
+            // Poll logs every 2 seconds
+            this.logPollInterval = setInterval(() => this.fetchLogs(), 2000);
+        },
+
+        async fetchAll() {
+            await Promise.allSettled([
+                this.fetchStatus(),
+                this.fetchAgents(),
+                this.fetchQueue(),
+                this.fetchTokens(),
+            ]);
+        },
+
+        async fetchStatus() {
+            try {
+                const res = await fetch('/api/status');
+                if (res.ok) this.status = await res.json();
+            } catch (e) {
+                this.status = { status: 'unreachable', pid: null };
+            }
+        },
+
+        async fetchAgents() {
+            try {
+                const res = await fetch('/api/agents');
+                if (res.ok) {
+                    const data = await res.json();
+                    this.agents = data.agents || [];
+                }
+            } catch (e) { /* ignore */ }
+        },
+
+        async fetchQueue() {
+            try {
+                const res = await fetch('/api/queue');
+                if (res.ok) {
+                    const data = await res.json();
+                    this.claimed = data.claimed || [];
+                    this.retryQueue = data.retry_queue || [];
+                }
+            } catch (e) { /* ignore */ }
+        },
+
+        async fetchTokens() {
+            try {
+                const res = await fetch('/api/tokens');
+                if (res.ok) this.tokens = await res.json();
+            } catch (e) { /* ignore */ }
+        },
+
+        async fetchLogs() {
+            try {
+                let url = '/api/logs?lines=200';
+                if (this.lastTimestamp) {
+                    url += '&since=' + encodeURIComponent(this.lastTimestamp);
+                }
+                const res = await fetch(url);
+                if (res.ok) {
+                    const data = await res.json();
+                    if (this.lastTimestamp && data.logs.length > 0) {
+                        // Append new lines
+                        this.logs = this.logs.concat(data.logs);
+                        // Keep last 1000 lines
+                        if (this.logs.length > 1000) {
+                            this.logs = this.logs.slice(-1000);
+                        }
+                    } else if (!this.lastTimestamp) {
+                        this.logs = data.logs || [];
+                    }
+                    if (data.last_timestamp) {
+                        this.lastTimestamp = data.last_timestamp;
+                    }
+                    if (this.autoScroll) {
+                        this.$nextTick(() => {
+                            const viewer = this.$refs.logViewer;
+                            if (viewer) viewer.scrollTop = viewer.scrollHeight;
+                        });
+                    }
+                }
+            } catch (e) { /* ignore */ }
+        },
+
+        async loadConfig() {
+            try {
+                const res = await fetch('/api/config');
+                if (res.ok) {
+                    const data = await res.json();
+                    this.configContent = data.content || '';
+                    this.configError = '';
+                }
+            } catch (e) {
+                this.configError = 'Failed to load configuration';
+            }
+        },
+
+        async saveConfig() {
+            this.savingConfig = true;
+            this.configError = '';
+            this.configSaved = false;
+            try {
+                const res = await fetch('/api/config', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ content: this.configContent }),
+                });
+                const data = await res.json();
+                if (res.ok) {
+                    this.configSaved = true;
+                    setTimeout(() => this.configSaved = false, 3000);
+                } else {
+                    this.configError = data.error || 'Failed to save';
+                }
+            } catch (e) {
+                this.configError = 'Failed to save configuration';
+            } finally {
+                this.savingConfig = false;
+            }
+        },
+
+        async controlAction(action) {
+            this.controlling = true;
+            try {
+                await fetch('/api/control', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action }),
+                });
+                // Refresh status after a short delay
+                setTimeout(() => this.fetchStatus(), 1000);
+            } catch (e) { /* ignore */ }
+            finally {
+                this.controlling = false;
+            }
+        },
+
+        formatNumber(n) {
+            if (n == null) return '0';
+            n = parseInt(n);
+            if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+            if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+            return n.toString();
+        },
+
+        formatElapsed(seconds) {
+            if (seconds == null) return '-';
+            seconds = Math.round(seconds);
+            if (seconds < 60) return seconds + 's';
+            const mins = Math.floor(seconds / 60);
+            const secs = seconds % 60;
+            if (mins < 60) return mins + 'm ' + secs + 's';
+            const hours = Math.floor(mins / 60);
+            const remainMins = mins % 60;
+            return hours + 'h ' + remainMins + 'm';
+        },
+    };
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Symphony Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+    <style>
+        :root {
+            --pico-font-size: 15px;
+        }
+        body { padding: 0; margin: 0; }
+        nav.top-bar {
+            background: var(--pico-primary-background);
+            color: var(--pico-primary-inverse);
+            padding: 0.5rem 1.5rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+        nav.top-bar h1 { margin: 0; font-size: 1.2rem; }
+        .status-badge {
+            display: inline-block;
+            padding: 0.2rem 0.6rem;
+            border-radius: 4px;
+            font-size: 0.8rem;
+            font-weight: 600;
+        }
+        .status-running { background: #22c55e; color: #fff; }
+        .status-stopped { background: #ef4444; color: #fff; }
+        .dashboard { padding: 1rem 1.5rem; }
+        .grid-cards {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 1rem;
+            margin-bottom: 1rem;
+        }
+        .card {
+            background: var(--pico-card-background-color);
+            border: 1px solid var(--pico-muted-border-color);
+            border-radius: 8px;
+            padding: 1rem;
+        }
+        .card h3 { margin-top: 0; font-size: 1rem; }
+        .stat-number { font-size: 1.8rem; font-weight: 700; }
+        .stat-label { font-size: 0.8rem; color: var(--pico-muted-color); }
+        .stats-row {
+            display: flex;
+            gap: 2rem;
+        }
+        table { font-size: 0.85rem; margin: 0; }
+        table td, table th { padding: 0.4rem 0.6rem; }
+        .log-viewer {
+            background: #1a1a2e;
+            color: #e0e0e0;
+            font-family: 'Fira Code', 'Cascadia Code', monospace;
+            font-size: 0.75rem;
+            padding: 0.8rem;
+            border-radius: 6px;
+            max-height: 400px;
+            overflow-y: auto;
+            white-space: pre-wrap;
+            word-break: break-all;
+            line-height: 1.5;
+        }
+        .log-viewer .log-line:hover { background: rgba(255,255,255,0.05); }
+        .config-editor {
+            width: 100%;
+            min-height: 300px;
+            font-family: 'Fira Code', 'Cascadia Code', monospace;
+            font-size: 0.8rem;
+            border-radius: 6px;
+            padding: 0.8rem;
+            resize: vertical;
+        }
+        .btn-group { display: flex; gap: 0.5rem; }
+        .btn-sm {
+            padding: 0.3rem 0.8rem;
+            font-size: 0.8rem;
+        }
+        .elapsed { color: var(--pico-muted-color); }
+        .empty-state {
+            text-align: center;
+            padding: 2rem;
+            color: var(--pico-muted-color);
+        }
+        .tab-buttons { display: flex; gap: 0.5rem; margin-bottom: 0.5rem; }
+        .tab-buttons button {
+            padding: 0.3rem 0.8rem;
+            font-size: 0.8rem;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        .tab-buttons button.active {
+            background: var(--pico-primary-background);
+            color: var(--pico-primary-inverse);
+        }
+        [x-cloak] { display: none !important; }
+    </style>
+</head>
+<body x-data="dashboard()" x-init="init()">
+
+<nav class="top-bar">
+    <div style="display:flex;align-items:center;gap:1rem;">
+        <h1>Symphony</h1>
+        <span class="status-badge" :class="status.status === 'running' ? 'status-running' : 'status-stopped'"
+              x-text="status.status || 'unknown'"></span>
+    </div>
+    <div class="btn-group">
+        <button class="btn-sm" @click="controlAction('start')" :disabled="status.status === 'running'"
+                :aria-busy="controlling">Start</button>
+        <button class="btn-sm secondary" @click="controlAction('stop')" :disabled="status.status !== 'running'"
+                :aria-busy="controlling">Stop</button>
+    </div>
+</nav>
+
+<div class="dashboard">
+    <!-- Stats cards -->
+    <div class="grid-cards">
+        <div class="card">
+            <h3>Agents</h3>
+            <div class="stats-row">
+                <div>
+                    <div class="stat-number" x-text="agents.length">0</div>
+                    <div class="stat-label">Running</div>
+                </div>
+                <div>
+                    <div class="stat-number" x-text="claimed.length">0</div>
+                    <div class="stat-label">Claimed</div>
+                </div>
+                <div>
+                    <div class="stat-number" x-text="retryQueue.length">0</div>
+                    <div class="stat-label">Retry Queue</div>
+                </div>
+            </div>
+        </div>
+        <div class="card">
+            <h3>Token Usage</h3>
+            <div class="stats-row">
+                <div>
+                    <div class="stat-number" x-text="formatNumber(tokens.input_tokens)">0</div>
+                    <div class="stat-label">Input</div>
+                </div>
+                <div>
+                    <div class="stat-number" x-text="formatNumber(tokens.output_tokens)">0</div>
+                    <div class="stat-label">Output</div>
+                </div>
+                <div>
+                    <div class="stat-number" x-text="'$' + (tokens.estimated_cost_usd || 0).toFixed(2)">$0.00</div>
+                    <div class="stat-label">Est. Cost</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Running Agents -->
+    <div class="card" style="margin-bottom:1rem;">
+        <h3>Running Agents</h3>
+        <template x-if="agents.length === 0">
+            <div class="empty-state">No agents running</div>
+        </template>
+        <template x-if="agents.length > 0">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Issue</th>
+                        <th>Title</th>
+                        <th>Stage</th>
+                        <th>PID</th>
+                        <th>Elapsed</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <template x-for="agent in agents" :key="agent.issue_id">
+                        <tr>
+                            <td><a :href="agent.issue_url" target="_blank" x-text="agent.issue_identifier"></a></td>
+                            <td x-text="agent.issue_title"></td>
+                            <td x-text="agent.stage || '-'"></td>
+                            <td x-text="agent.pid"></td>
+                            <td class="elapsed" x-text="formatElapsed(agent.elapsed_seconds)"></td>
+                        </tr>
+                    </template>
+                </tbody>
+            </table>
+        </template>
+    </div>
+
+    <!-- Queue -->
+    <div class="card" style="margin-bottom:1rem;">
+        <h3>Queue</h3>
+        <div class="tab-buttons">
+            <button :class="queueTab === 'claimed' ? 'active' : ''" @click="queueTab = 'claimed'">
+                Claimed (<span x-text="claimed.length"></span>)
+            </button>
+            <button :class="queueTab === 'retry' ? 'active' : ''" @click="queueTab = 'retry'">
+                Retry (<span x-text="retryQueue.length"></span>)
+            </button>
+        </div>
+
+        <div x-show="queueTab === 'claimed'">
+            <template x-if="claimed.length === 0">
+                <div class="empty-state">No claimed issues</div>
+            </template>
+            <template x-if="claimed.length > 0">
+                <table>
+                    <thead><tr><th>Claim Key</th></tr></thead>
+                    <tbody>
+                        <template x-for="key in claimed" :key="key">
+                            <tr><td x-text="key"></td></tr>
+                        </template>
+                    </tbody>
+                </table>
+            </template>
+        </div>
+
+        <div x-show="queueTab === 'retry'">
+            <template x-if="retryQueue.length === 0">
+                <div class="empty-state">No retries queued</div>
+            </template>
+            <template x-if="retryQueue.length > 0">
+                <table>
+                    <thead>
+                        <tr><th>Issue</th><th>Attempt</th><th>Remaining</th><th>Error</th></tr>
+                    </thead>
+                    <tbody>
+                        <template x-for="entry in retryQueue" :key="entry.issue_id">
+                            <tr>
+                                <td x-text="entry.issue_id"></td>
+                                <td x-text="entry.attempt"></td>
+                                <td x-text="formatElapsed(entry.remaining_seconds)"></td>
+                                <td x-text="entry.error"></td>
+                            </tr>
+                        </template>
+                    </tbody>
+                </table>
+            </template>
+        </div>
+    </div>
+
+    <!-- Logs -->
+    <div class="card" style="margin-bottom:1rem;">
+        <div style="display:flex;justify-content:space-between;align-items:center;">
+            <h3>Logs</h3>
+            <label style="font-size:0.8rem;display:flex;align-items:center;gap:0.3rem;">
+                <input type="checkbox" x-model="autoScroll" role="switch" style="margin:0;">
+                Auto-scroll
+            </label>
+        </div>
+        <div class="log-viewer" x-ref="logViewer">
+            <template x-for="(line, i) in logs" :key="i">
+                <div class="log-line" x-text="line"></div>
+            </template>
+            <template x-if="logs.length === 0">
+                <div class="empty-state" style="color:#666;">No log entries</div>
+            </template>
+        </div>
+    </div>
+
+    <!-- Configuration -->
+    <div class="card">
+        <div style="display:flex;justify-content:space-between;align-items:center;">
+            <h3>Workflow Configuration</h3>
+            <div class="btn-group">
+                <button class="btn-sm" @click="saveConfig()" :aria-busy="savingConfig">Save</button>
+                <button class="btn-sm secondary" @click="loadConfig()">Reload</button>
+            </div>
+        </div>
+        <div x-show="configError" style="color:var(--pico-del-color);font-size:0.8rem;margin-bottom:0.5rem;" x-text="configError"></div>
+        <div x-show="configSaved" style="color:var(--pico-ins-color);font-size:0.8rem;margin-bottom:0.5rem;">Configuration saved</div>
+        <textarea class="config-editor" x-model="configContent"></textarea>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js" defer></script>
+<script src="app.js"></script>
+</body>
+</html>

--- a/public/router.php
+++ b/public/router.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Built-in PHP server router for Symphony Web UI.
+ *
+ * Routes API requests to the ApiHandler, serves static files otherwise.
+ */
+$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
+// API routes
+if (str_starts_with($uri, '/api/')) {
+    require __DIR__.'/../app/Http/ApiHandler.php';
+    exit;
+}
+
+// Static files — let the built-in server handle them
+if ($uri !== '/' && file_exists(__DIR__.$uri)) {
+    return false;
+}
+
+// SPA fallback — serve index.html for all other routes
+$indexPath = __DIR__.'/index.html';
+if (file_exists($indexPath)) {
+    readfile($indexPath);
+    exit;
+}
+
+http_response_code(404);
+echo 'Not Found';

--- a/tests/Unit/ServeCommandTest.php
+++ b/tests/Unit/ServeCommandTest.php
@@ -1,0 +1,10 @@
+<?php
+
+use App\Commands\ServeCommand;
+
+it('has correct command signature', function () {
+    $command = new ServeCommand;
+
+    expect($command->getName())->toBe('serve');
+    expect($command->getDescription())->toBe('Start the Symphony web UI server');
+});

--- a/tests/Unit/StateStoreTest.php
+++ b/tests/Unit/StateStoreTest.php
@@ -1,0 +1,228 @@
+<?php
+
+use App\Config\StageConfig;
+use App\State\StateStore;
+use App\Tracker\Issue;
+
+function createTempStore(): StateStore
+{
+    $path = sys_get_temp_dir().'/symphony_test_'.uniqid().'.sqlite';
+
+    return new StateStore($path);
+}
+
+function makeStateTestIssue(string $id = '1'): Issue
+{
+    return new Issue(
+        id: $id,
+        identifier: "test#{$id}",
+        title: "Test Issue {$id}",
+        description: 'Description',
+        priority: 1,
+        state: 'open',
+        branchName: "symphony/test_{$id}",
+        url: "https://github.com/test/repo/issues/{$id}",
+        labels: ['stage:plan'],
+        blockedBy: [],
+        createdAt: new DateTimeImmutable('2025-01-01T00:00:00Z'),
+        updatedAt: new DateTimeImmutable('2025-01-01T00:00:00Z'),
+    );
+}
+
+it('initializes with default daemon status', function () {
+    $store = createTempStore();
+    $status = $store->getDaemonStatus();
+
+    expect($status['status'])->toBe('stopped');
+    expect($status['pid'])->toBeNull();
+});
+
+it('marks daemon as running and stopped', function () {
+    $store = createTempStore();
+
+    $store->markRunning(12345, '/path/to/workflow.yml');
+    $status = $store->getDaemonStatus();
+
+    expect($status['status'])->toBe('running');
+    expect((int) $status['pid'])->toBe(12345);
+    expect($status['workflow_path'])->toBe('/path/to/workflow.yml');
+    expect($status['started_at'])->not->toBeNull();
+
+    $store->markStopped();
+    $status = $store->getDaemonStatus();
+
+    expect($status['status'])->toBe('stopped');
+});
+
+it('syncs and retrieves agents', function () {
+    $store = createTempStore();
+    $issue = makeStateTestIssue();
+
+    $running = [
+        '1' => [
+            'pid' => 100,
+            'issue' => $issue,
+            'stage' => null,
+            'startedAt' => hrtime(true),
+        ],
+    ];
+
+    $store->syncAgents($running);
+    $agents = $store->getAgents();
+
+    expect($agents)->toHaveCount(1);
+    expect($agents[0]['issue_identifier'])->toBe('test#1');
+    expect($agents[0]['issue_title'])->toBe('Test Issue 1');
+    expect((int) $agents[0]['pid'])->toBe(100);
+});
+
+it('syncs agents with stage config', function () {
+    $store = createTempStore();
+    $issue = makeStateTestIssue();
+    $stage = new StageConfig(
+        ['name' => 'plan', 'trigger' => 'stage:plan'],
+        ['command' => 'claude -p', 'max_turns' => 10, 'turn_timeout_ms' => 3600000, 'stall_timeout_ms' => 300000],
+        'Plan prompt'
+    );
+
+    $running = [
+        '1' => [
+            'pid' => 200,
+            'issue' => $issue,
+            'stage' => $stage,
+            'startedAt' => hrtime(true),
+        ],
+    ];
+
+    $store->syncAgents($running);
+    $agents = $store->getAgents();
+
+    expect($agents[0]['stage'])->toBe('plan');
+});
+
+it('syncs and retrieves claimed keys', function () {
+    $store = createTempStore();
+
+    $claimed = ['1' => true, '2:plan' => true, '3:implement' => true];
+
+    $store->syncClaimed($claimed);
+    $result = $store->getClaimed();
+
+    expect($result)->toHaveCount(3);
+    expect($result)->toContain('1');
+    expect($result)->toContain('2:plan');
+    expect($result)->toContain('3:implement');
+});
+
+it('syncs and retrieves retry queue', function () {
+    $store = createTempStore();
+
+    $dueAt = hrtime(true) + 10_000_000_000; // 10 seconds from now
+    $retryQueue = [
+        'issue-1' => [
+            'attempt' => 2,
+            'dueAt' => $dueAt,
+            'error' => 'failure',
+        ],
+    ];
+
+    $store->syncRetryQueue($retryQueue);
+    $result = $store->getRetryQueue();
+
+    expect($result)->toHaveCount(1);
+    expect($result[0]['issue_id'])->toBe('issue-1');
+    expect((int) $result[0]['attempt'])->toBe(2);
+    expect($result[0]['error'])->toBe('failure');
+});
+
+it('syncs and retrieves token totals', function () {
+    $store = createTempStore();
+
+    $totals = [
+        'input_tokens' => 50000,
+        'output_tokens' => 12000,
+        'seconds' => 45.5,
+    ];
+
+    $store->syncTokenTotals($totals);
+    $result = $store->getTokenTotals();
+
+    expect((int) $result['input_tokens'])->toBe(50000);
+    expect((int) $result['output_tokens'])->toBe(12000);
+    expect((float) $result['seconds'])->toBe(45.5);
+});
+
+it('flushes all state atomically', function () {
+    $store = createTempStore();
+    $issue = makeStateTestIssue();
+
+    $running = [
+        '1' => [
+            'pid' => 300,
+            'issue' => $issue,
+            'stage' => null,
+            'startedAt' => hrtime(true),
+        ],
+    ];
+    $claimed = ['1' => true];
+    $retryQueue = [];
+    $totals = ['input_tokens' => 1000, 'output_tokens' => 500, 'seconds' => 10.0];
+
+    $store->flush($running, $claimed, $retryQueue, $totals);
+
+    expect($store->getAgents())->toHaveCount(1);
+    expect($store->getClaimed())->toHaveCount(1);
+    expect($store->getRetryQueue())->toHaveCount(0);
+    expect((int) $store->getTokenTotals()['input_tokens'])->toBe(1000);
+});
+
+it('replaces previous state on re-flush', function () {
+    $store = createTempStore();
+    $issue1 = makeStateTestIssue('1');
+    $issue2 = makeStateTestIssue('2');
+
+    // First flush
+    $store->flush(
+        ['1' => ['pid' => 100, 'issue' => $issue1, 'stage' => null, 'startedAt' => hrtime(true)]],
+        ['1' => true],
+        [],
+        ['input_tokens' => 100, 'output_tokens' => 50, 'seconds' => 1.0]
+    );
+
+    expect($store->getAgents())->toHaveCount(1);
+
+    // Second flush with different data
+    $store->flush(
+        ['2' => ['pid' => 200, 'issue' => $issue2, 'stage' => null, 'startedAt' => hrtime(true)]],
+        ['2' => true],
+        ['1' => ['attempt' => 1, 'dueAt' => hrtime(true), 'error' => 'failed']],
+        ['input_tokens' => 200, 'output_tokens' => 100, 'seconds' => 2.0]
+    );
+
+    $agents = $store->getAgents();
+    expect($agents)->toHaveCount(1);
+    expect($agents[0]['issue_identifier'])->toBe('test#2');
+    expect($store->getRetryQueue())->toHaveCount(1);
+    expect((int) $store->getTokenTotals()['input_tokens'])->toBe(200);
+});
+
+it('updates heartbeat timestamp', function () {
+    $store = createTempStore();
+    $store->markRunning(1, '');
+
+    $before = $store->getDaemonStatus()['updated_at'];
+    sleep(1); // Ensure different second
+    $store->heartbeat();
+    $after = $store->getDaemonStatus()['updated_at'];
+
+    expect($after)->not->toBe($before);
+});
+
+it('initializes token totals with zeros', function () {
+    $store = createTempStore();
+    $totals = $store->getTokenTotals();
+
+    expect((int) $totals['input_tokens'])->toBe(0);
+    expect((int) $totals['output_tokens'])->toBe(0);
+    expect((float) $totals['seconds'])->toBe(0.0);
+});


### PR DESCRIPTION
## Summary

- Adds a SQLite-backed `StateStore` that the orchestrator flushes each tick, making daemon state observable externally
- Adds a `serve` command (`php application serve`) that starts a lightweight web server with JSON API endpoints for status, agents, queue, tokens, logs, config (view/edit), and start/stop controls
- Adds an Alpine.js + Pico CSS dashboard SPA with live-polling, auto-scrolling log viewer, and inline workflow YAML editor

Closes #2

## Test plan

- [x] 12 new tests pass (11 for StateStore, 1 for ServeCommand)
- [x] All existing tests unaffected
- [x] Linter passes
- [ ] Manual: run `php application serve`, verify dashboard loads at http://127.0.0.1:8085
- [ ] Manual: start orchestrator with `php application run`, verify agents/queue/tokens update in dashboard
- [ ] Manual: edit workflow YAML in dashboard, verify save and hot-reload on next tick
- [ ] Manual: test start/stop controls from dashboard

https://claude.ai/code/session_01WtAGN6QcZBfrPMTPsLhGoy